### PR TITLE
Add tests with Julia 1.6 in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.4'
           - '1.5'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
I added the tests for Julia 1.6 since they do not seem to pass on my computer, and the Project.toml file states that GeometricFlux is compatible with Julia 1.6