### PR TITLE
Add more example scripts

### DIFF
--- a/examples/gcn_gpu.jl
+++ b/examples/gcn_gpu.jl
@@ -23,16 +23,15 @@ target_catg = 7
 epochs = 100
 
 ## Preprocessing data
-train_X = Matrix{Float32}(features)  # dim: num_features * num_nodes
-train_y = Matrix{Float32}(labels) # dim: target_catg * num_nodes
-adj_mat = Matrix{Float32}(adjacency_matrix(g))
+train_X = Matrix{Float32}(features) |> gpu             # dim: num_features * num_nodes
+train_y = Matrix{Float32}(labels) |> gpu               # dim: target_catg * num_nodes
+adj_mat = Matrix{Float32}(adjacency_matrix(g)) |> gpu
 
-model = Chain(
-    GCNConv(adj_mat, num_features=>hidden, relu),
-    Dropout(0.5),
-    GCNConv(adj_mat, hidden=>target_catg),
-)
 ## Model
+model = Chain(GCNConv(adj_mat, num_features=>hidden, relu),
+              Dropout(0.5),
+              GCNConv(adj_mat, hidden=>target_catg),
+              ) |> gpu
 
 ## Loss
 loss(x, y) = logitcrossentropy(model(x), y)


### PR DESCRIPTION
- rename `examples/gcn.jl` --> `examples/gcn_gpu.jl`. (this actually does not run, but IDK if its my setup or a bug)
- added `examples/gcn.jl` (original example but w/o the `|> gpu` parts
- added `examples/gcn_featured_graph.jl` (was a little more tedious to figure out how to make this work than i hoped from the docs alone)
- note Dropout is broken for the FeaturedGraph example