### PR TITLE
remove learnable parameters when bias=false

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -252,7 +252,7 @@ the layer instead of only the features.
 - `in`: The dimension of input features.
 - `out`: The dimension of output features.
 - `bias::Bool`: Keyword argument, whether to learn the additive bias.
-- `heads`: number attention heads 
+- `heads`: Number attention heads 
 - `concat`: Concatenate layer output or not. If not, layer output is averaged.
 - `negative_slope::Real`: Keyword argument, the parameter of LeakyReLU.
 """

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -253,7 +253,7 @@ the layer instead of only the features.
 - `out`: The dimension of output features.
 - `bias::Bool`: Keyword argument, whether to learn the additive bias.
 - `heads`: number attention heads 
-- `concat`
+- `concat`: Concatenate layer output or not. If not, layer output is averaged.
 - `negative_slope::Real`: Keyword argument, the parameter of LeakyReLU.
 """
 struct GATConv{V<:AbstractFeaturedGraph, T, A<:AbstractMatrix{T}, B} <: MessagePassing

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -61,6 +61,11 @@ adj_single_vertex = T[0. 0. 0. 1.;
             @test size(g.weight) == size(gc.weight)
             @test size(g.bias) == size(gc.bias)
         end
+
+        @testset "bias=false" begin
+            length(Flux.params(GCNConv(2=>3))) == 2
+            length(Flux.params(GCNConv(2=>3, bias=false))) == 1
+        end
     end
 
 
@@ -118,6 +123,11 @@ adj_single_vertex = T[0. 0. 0. 1.;
             @test size(g.weight) == size(cc.weight)
             @test size(g.bias) == size(cc.bias)
         end
+
+        @testset "bias=false" begin
+            length(Flux.params(ChebConv(2=>3, 3))) == 2
+            length(Flux.params(ChebConv(2=>3, 3, bias=false))) == 1
+        end
     end
 
     @testset "GraphConv" begin
@@ -169,6 +179,12 @@ adj_single_vertex = T[0. 0. 0. 1.;
             @test size(g.weight1) == size(gc.weight1)
             @test size(g.weight2) == size(gc.weight2)
             @test size(g.bias) == size(gc.bias)
+        end
+
+
+        @testset "bias=false" begin
+            length(Flux.params(GraphConv(2=>3))) == 3
+            length(Flux.params(GraphConv(2=>3, bias=false))) == 2
         end
     end
 
@@ -235,6 +251,11 @@ adj_single_vertex = T[0. 0. 0. 1.;
         #         @test size(g.a) == size(gat.a)
         #     end
         # end
+
+        @testset "bias=false" begin
+            length(Flux.params(GATConv(2=>3))) == 3
+            length(Flux.params(GATConv(2=>3, bias=false))) == 2
+        end
     end
 
     @testset "GatedGraphConv" begin


### PR DESCRIPTION
On current master, `bias=false` initialized the weights to zero, but the bias remains a learnable parameter. This PR fixes this problem and makes the interface consistent with Flux's initialization. 

This PR also imposes stricter parametrization on layers' fields

This a breaking PR